### PR TITLE
Adds UpdateOne Route for toggling favoriteParks

### DIFF
--- a/app/models/favoriteParks.js
+++ b/app/models/favoriteParks.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose')
 const favoriteParksSchema = new mongoose.Schema({
   list: {
     type: Array,
-    required: true
+    required: false
   },
   owner: {
     type: mongoose.Schema.Types.ObjectId,

--- a/app/routes/favoriteParks_routes.js
+++ b/app/routes/favoriteParks_routes.js
@@ -77,6 +77,32 @@ router.patch('/favoriteParks/:id/update', requireToken, (req, res) => {
     .catch(err => handle(err, res))
 })
 
+// UPDATE
+router.patch('/favoriteParks/:id/updateOne', requireToken, (req, res) => {
+  // req.params.id will be set based on the `:id` in the route
+  FavoriteParks.findById(req.params.id)
+    .then(handle404)
+    .then(favoriteParks => {
+      // pass the `req` object and the Mongoose record to `requireOwnership`
+      // it will throw an error if the current user isn't the owner
+      requireOwnership(req, favoriteParks)
+
+      const newParksList = favoriteParks.list.includes(req.body.favoriteParks.list)
+        ? favoriteParks.list.filter(current => current !== req.body.favoriteParks.list)
+        : favoriteParks.list.concat(req.body.favoriteParks.list)
+
+      favoriteParks.list = newParksList
+
+      return favoriteParks.save()
+    })
+    .then(favoriteParks => {
+      console.log(favoriteParks)
+      res.status(200).json({ favoriteParks: favoriteParks })
+    })
+    // if an error occurs, pass it to the handler
+    .catch(err => handle(err, res))
+})
+
 // DELETE
 router.delete('/favoriteParks/:id/delete', requireToken, (req, res) => {
   FavoriteParks.findById(req.params.id)

--- a/scripts/favoriteParks/updateOne.sh
+++ b/scripts/favoriteParks/updateOne.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+API="http://localhost:4741"
+URL_PATH="/favoriteParks"
+
+curl "${API}${URL_PATH}/${ID}/updateOne" \
+  --include \
+  --request PATCH \
+  --header "Content-Type: application/json" \
+  --header "Authorization: Bearer ${TOKEN}" \
+  --data '{
+    "favoriteParks": {
+      "list": ["dena"]
+    }
+  }'
+
+echo


### PR DESCRIPTION
This route is passed a parkCode associated with the park that a user initiated the api call from. The route checks to see if the code already exists in the user's favoriteParks.list, and if true it removes the parkCode from the list. If false, it adds the parkCode to the list.

This "update" route uses dot notation and favoriteParks.save() instead of favoriteParks.update() because the client response needed to include the complete favoriteParks.list. Model.update() returns the number of modified documents, instead of the list.

Closes #4 #5 #6 

**IMPORTANT: Changes the FavoriteParks Model to no longer require list**
If a user updateOne resulted in the favoriteParks.list being an empty array, Mongoose would throw a validation error. Required was set to false to remedy this, and seems appropriate since the user can use the app without needing a favoriteParks list.